### PR TITLE
Enable no waiting between kills and deviation>1

### DIFF
--- a/src/havoc.erl
+++ b/src/havoc.erl
@@ -126,11 +126,13 @@ handle_info(_Msg, State) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
--spec schedule(non_neg_integer(), non_neg_integer()) -> reference().
+-spec schedule(non_neg_integer(), number()) -> ok.
 schedule(Wait, Deviation) ->
-    Diff = round(Wait * Deviation),
-    Interval = rand:uniform(Diff * 2) + Wait - Diff,
-    erlang:send_after(Interval, self(), kill_something).
+    case round(Wait * (1 + Deviation * (2 * rand:uniform() - 1))) of
+        Delay when Delay > 0 -> erlang:send_after(Delay, self(), kill_something);
+        _ -> self() ! kill_something
+    end,
+    ok.
 
 -spec try_kill_one(#state{}) -> {ok, term()} | {error, nothing_to_kill}.
 try_kill_one(State) ->


### PR DESCRIPTION
I improved the scheduling calculation a bit. It will now accept `0` for `Wait` ("kill as fast as possible") and any number (even negative, its of no consequence) for `Deviation`. The spec was also wrong in regard to the deviation argument. I also replaced the return value with ok, as the reference it returned was never used, and as I replaced the no-wait case with an instant send via `!`, there is no reference returned in those cases.