### PR TITLE
Introduce callback for user-defined killable decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ allowed options
   (defaults to all applications except `kernel` and `havoc`)
 * `supervisors` - A list of supervisors that you want to target. Can be any
   valid supervisor reference. (defaults to all supervisors)
+* `killable_callback` - A `Fun` that gets called to decide if a `pid` or
+  `port` may be killed or not by returning `true` or `false`.
 * `prekill_callback` - A `Fun` that gets called just before killing.
 
 You can specify options using `havoc:on/1`.


### PR DESCRIPTION
In #9 I requested an option to exclude certain modules from killing.

On second thought, this seems a little inflexible, and doesn't fit in with the rest of the options (they are all _inclusive_, while this would be an _exclusive_ one). With this PR, I propose an approach similar to the one discussed post-merge in #4, a second callback (`killable_callback`) by which the user can decide if he wants a pid (or port) killed or not. This may be not as comfortable as just giving a list of modules, but lets the user have more, better control.

On the side, I also improved the specs for `prekill_callback` and `default_prekill_callback` to better match the ones introduced with `killable_callback` and `default_killable_callback`.

Also, I replaced the `apply(Fun, [PidOrPort])` call in `prekill_callback` with `Fun(PidOrPort)`. From the Erlang docs on `apply`: "If the number of elements in the arguments are known at compile time, the call is better written as Fun(Arg1, Arg2, ... ArgN)."