### PR TITLE
Exclude application_controller processes

### DIFF
--- a/src/havoc.erl
+++ b/src/havoc.erl
@@ -300,6 +300,7 @@ is_supervisor_or_appmaster(Pid) ->
         end,
     case Translate of
         {supervisor, _, _} -> true;
+        {application_controller, _, _} -> true;
         {application_master, _, _} -> true;
         _ -> false
     end.


### PR DESCRIPTION
`havoc` will kill the `application_controller` process, which it shouldn't do. Though the Erlang docs say that it is part of the `kernel` application, `application:get_application(whereis(application_controller))` really returns `undefined`, which is why `havoc` doesn't recognize it as belonging to the non-killable applications. I suspect there are still more things like this around, but AFAIK there is no easy way to find out.