### PR TITLE
Prevent crashing in supervisor_killable

### DIFF
--- a/src/havoc.erl
+++ b/src/havoc.erl
@@ -274,7 +274,13 @@ supervisor_killable1(_, []) ->
 supervisor_killable1(Pid, [{_, Pid, _, _}|_]) ->
     true;
 supervisor_killable1(Pid, [{_, SupPid, supervisor, _}|Children]) ->
-    supervisor_killable1(Pid, Children ++ supervisor:which_children(SupPid));
+    SupChildren = try
+        supervisor:which_children(SupPid)
+    catch
+        exit:{noproc, _} ->
+            []
+    end,
+    supervisor_killable1(Pid, Children ++ SupChildren);
 supervisor_killable1(Pid, [_|Children]) ->
     supervisor_killable1(Pid, Children).
 


### PR DESCRIPTION
`supervisor_killable` checks if a given Pid is part of the given supersiors' tree via `supervisor:which_children`. It may however happen that some of the given supervisors are gone at the time of querying, either by themselves or a sub-supervisor having been killed or crashed or exited by natural means. In that case, `supervisor:which_children` will raise an exit exception, and `havoc` will crash.